### PR TITLE
download.service.ts replace link.click() to synthetic event

### DIFF
--- a/libs/download.service.ts
+++ b/libs/download.service.ts
@@ -57,7 +57,7 @@ export class DownloadFileService extends BaseHttpService {
         link.download = filename;
         link.style.display = 'none';
         document.body.appendChild(link);
-        link.click();
+        link.dispatchEvent(new MouseEvent('click'));
         window.URL.revokeObjectURL(href);
         link.remove();
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@luxbss/gengen",
-    "version": "1.2.8",
+    "version": "1.2.9",
     "description": "Tool for generating models and Angular services based on OpenAPIs and Swagger's JSON",
     "bin": {
         "gengen": "./bin/index.js"


### PR DESCRIPTION
Replaced link.click() to synthetic event dispatch to prevent unnecessary triggering events on document level